### PR TITLE
feat: add href param for isRTL function

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ HtmlWebpackInjectStylePlugin.prototype.filterStyleAssets = function (pluginData,
 HtmlWebpackInjectStylePlugin.prototype.generateScriptNode = function (styleAssets, isRtl) {
   var styleAssetsHref = JSON.stringify(styleAssets.map(tag => tag.attributes.href.match(/(.*)\.css$/)[1]));
   var genRtlFun = typeof isRtl === 'function'
-    ? `new Function("return (${isRtl.toString().split('\n').join('\\n')})(window)")`
+    ? `new Function("href","return (${isRtl.toString().split('\n').join('\\n')})(window, href)")`
     : `new Function("return ${isRtl}.test(document.cookie)")`;
   return {
     tagName: 'script',
@@ -116,7 +116,7 @@ HtmlWebpackInjectStylePlugin.prototype.generateScriptNode = function (styleAsset
         var isRTL = ${genRtlFun};
         var head = document.querySelector('head');
         ${styleAssetsHref}.forEach(function (href) {
-          var fullhref = isRTL() ? href + '.rtl.css' : href + '.css';
+          var fullhref = isRTL(href) ? href + '.rtl.css' : href + '.css';
           var linkTag = document.createElement("link");
           linkTag.rel = "stylesheet";
           linkTag.type = "text/css";


### PR DESCRIPTION
Add the href param for isRTL function.

sometimes we don't want to replace all the css link with rtl. For example some lib like xxdesign has done rtl adaptation.

so that we can use like:
```js
new HtmlWebpackInjectStylePlugin({
  isRtl: function (window, href) {
    return !/xxx-design/.test(href) && /lang=(ar|he)/.test(window.location.href);
  },
})
```